### PR TITLE
Switch from mathptmx package to newtx package as CTAN recommends

### DIFF
--- a/tex/latex/seg/segabs.cls
+++ b/tex/latex/seg/segabs.cls
@@ -44,7 +44,7 @@
 \ExecuteOptions{times}
 \ProcessOptions*
 \LoadClass[11pt]{article}
-\ifthenelse{\boolean{@times}}{\RequirePackage{mathptmx}}{}
+\ifthenelse{\boolean{@times}}{\RequirePackage{newtxtext,newtxmath}}{}
 \DeclareSymbolFont{largesymbols}{OMX}{cmex}{m}{n}
 \RequirePackage{seg}
 \providecommand{\figdir}{.}


### PR DESCRIPTION
The mathptmx package is reck­oned to be ob­so­lete. Using newtx package produces better fonts for `\mathcal` symbols, and also fix the bug when `\mathbf` is applied to upper-case Greek letters.