### PR TITLE
Add doi to @article

### DIFF
--- a/bibtex/bst/seg/seg.bst
+++ b/bibtex/bst/seg/seg.bst
@@ -443,6 +443,17 @@ FUNCTION {format.doi.access}
   if$
 }
 
+FUNCTION {format.doi}
+{ doi empty$
+    { }
+    { "; doi: \href{https://doi.org/" * doi * "}{" * doi * "}" * }
+  if$
+  accessed empty$   % To avoid warning
+    { "" }
+    { "accessed " accessed * }
+  if$
+}
+
 FUNCTION {format.title}
 { title empty$
     { "" }
@@ -823,6 +834,7 @@ FUNCTION {article}
       format.pages output
     }
   if$
+  format.doi output
   new.block
   format.note output
   fin.entry


### PR DESCRIPTION
## This PR adds doi's to the article class, if they are provided.

### Status quo
![Status-quo](https://user-images.githubusercontent.com/8020943/152223720-3add5095-9e40-4ae8-a953-a5f0d8a59aa7.png)

### With PR, adding the doi
If the doi is provided in the `bib` file, e.g.:

    doi = {10.1093/gji/ggab238},

it will be rendered like
![PR-with-doi](https://user-images.githubusercontent.com/8020943/152223730-bc5051a4-b00e-44a2-a8e5-7dd54f074649.png)
(the doi is a hyperlink in the pdf leading directly to the article).


### Reasoning
I think for various reasons it is good today to add DOI's to references. It makes it easier for everyone (reviewers, readers, yourself) to find the references, and it is in the footstep of FAIR data and science.

I thought I'd create this PR - even though it might not be desirable to have it in `seg.bst`; but someone else trying to do the same thing might stumble upon this through an internet search...

### Warnings
- This is just my attempt at implementing this. I have very little experience with bst-files, and it might be a completely wrong approach. If you know a better way, please ignore my hack.
- My implementation requires `\href{}{}`, which might not be desired for the `seg.bst`; maybe something like `\url{}` would be preferred.